### PR TITLE
fix: discovery never ending and unable to stop discovery in some case.

### DIFF
--- a/BlueMoon/remoteselector.cpp
+++ b/BlueMoon/remoteselector.cpp
@@ -57,7 +57,7 @@ RemoteSelector::RemoteSelector(QWidget* parent)
     discoveryAgent_.reset(new QBluetoothServiceDiscoveryAgent(adapterAddress));
 
     connect(discoveryAgent_.data(), &QBluetoothServiceDiscoveryAgent::serviceDiscovered, this, &RemoteSelector::serviceDiscovered);
-    connect(discoveryAgent_.data(), &QBluetoothServiceDiscoveryAgent::serviceDiscovered, this, &RemoteSelector::discoveryFinished);
+    connect(discoveryAgent_.data(), &QBluetoothServiceDiscoveryAgent::finished, this, &RemoteSelector::discoveryFinished);
     connect(discoveryAgent_.data(), &QBluetoothServiceDiscoveryAgent::canceled, this, &RemoteSelector::discoveryFinished);
 
     ui->remoteDevices->setColumnWidth(3, 75);


### PR DESCRIPTION
Hi,

I noted that the discovery process never ending and in some case it is impossible to stop the discovery.
After investigation I found that the signal `QBluetoothServiceDiscoveryAgent::finished` was not bound to `discoveryFinished` method.

So for example if the discovery agent send a `finished` signal the ui still show a running discovery and if you try to stop the discovery using the `stop` button it does not work because the discovery was already finished and no `cancel` signal is sent.

I think this commit fix the bug.

Cheers,
Thomas Pierson
